### PR TITLE
Use const instead let on gh-pages index

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,8 +124,8 @@
     <header>
       <div class="header">
         <img src="cottage_logo.svg" alt="Cottage" class="logo">
-        <code class="sample-code">let cottage = require(<span class="high">'cottage'</span>)
-let app = cottage()
+        <code class="sample-code">const cottage = require(<span class="high">'cottage'</span>)
+const app = cottage()
 
 app.get(<span class="high">'/'</span>, function* (req, res) {
    return <span class="high">'Hello world!'</span>


### PR DESCRIPTION
You used `const` for declaration variable in README.md.
But index.html use `let`.
I think `cottage` and `app` are not mutable variables, is right?.