### PR TITLE
Fix the Handler argument types missing request.params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -257,10 +257,16 @@ declare namespace cottage {
         strict: boolean;
     }
 
+    interface CottageContext {
+        request: Request & {
+            params: Record<string, string>;
+        };
+    }
+
     type Context<
         StateT = DefaultState,
         CustomT = DefaultContext,
-    > = ParameterizedContext<StateT, CustomT>;
+    > = ParameterizedContext<StateT, CottageContext & CustomT>;
 
     /**
      * Cottage middleware is almost same with {@link KoaMiddleware},
@@ -283,8 +289,8 @@ declare namespace cottage {
     /**
      * Cottage accepts both cottage-style middleware and koa-style middleware.
      */
-    type KoaCompatibleMiddleware<StateT = DefaultState, CustomT = DefaultState> =
-        Middleware<StateT, CustomT> | KoaMiddleware<StateT, CustomT>;
+    type KoaCompatibleMiddleware<StateT = DefaultState, CustomT = DefaultContext> =
+        Middleware<StateT, CustomT> | KoaMiddleware<StateT, CottageContext & CustomT>;
 
     type Handler<StateT = DefaultState, CustomT = DefaultContext> =
         Router | KoaCompatibleMiddleware<StateT, CustomT>;


### PR DESCRIPTION
The inferred types for `Handler`s were missing the `ctx.request.params` property, resulting in an error when attempting to access them.

Also fixes the default value for `KoaCompatibleMiddleware`'s generic type `CustomT` (custom context) being wrong. The previous type was equivalent anyway, but it's still a misleading hint for developers.

Fixes #26 