### PR TITLE
Fix all Router options required

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -253,8 +253,8 @@ declare namespace cottage {
     }
 
     type RouterOptions = {
-        caseSensitive: boolean;
-        strict: boolean;
+        caseSensitive?: boolean;
+        strict?: boolean;
     }
 
     type Context<


### PR DESCRIPTION
The TypeScript types require that either all the options for `Router` be provided, or that the object isn't provided at all, despite the implementation allowing providing only some values.

https://github.com/therne/cottage/blob/7d6c930b14d8915f7567d435f29b69237aa17a9d/lib/Router.js#L24-L27

This PR fixes this by allowing some of the options to be left undefined.